### PR TITLE
Update to reqwest 0.11/tokio 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies.reqwest]
-version = "~0.10"
+version = "~0.11"
 default_features = false
 features = ["rustls-tls", "json"]
 
@@ -21,4 +21,4 @@ version = "~1.0"
 
 [dev-dependencies.tokio]
 features = ["macros"]
-version = "~0.2"
+version = "~1.0"


### PR DESCRIPTION
Trivial version bump, verified with `cargo test`.